### PR TITLE
Add simple tests for pew

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "test": "mocha --reporter spec --recursive ./test/*.spec.js"
   },
   "dependencies": {
     "body-parser": "^1.12.0",
     "cool-ascii-faces": "~1.3.x",
+    "debug": "^2.2.0",
     "express": "~4.9.x",
     "lodash": "^3.8.0",
     "slack-notify": "*"
@@ -25,5 +27,11 @@
     "heroku",
     "express"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "chai": "^2.3.0",
+    "mocha": "^2.2.5",
+    "sinon": "^1.14.1",
+    "supertest": "^1.0.1"
+  }
 }

--- a/router/routes/pew.js
+++ b/router/routes/pew.js
@@ -2,11 +2,12 @@
 
 var express = require('express');
 var router = express.Router();
+var debug = require('debug')('pew');
 
 // From slack-notify incoming webhook url
 var PEW_SLACK_WEBHOOK_URL = process.env['PEW_SLACK_WEBHOOK_URL'];
 var PEW_SLASH_TOKEN = process.env['PEW_SLASH_TOKEN'];
-var slack = require('slack-notify')(PEW_SLACK_WEBHOOK_URL);
+var slack = router.slack = require('slack-notify')(PEW_SLACK_WEBHOOK_URL);
 
 // POST /pew
 router.post('/', function(request, response) {
@@ -17,6 +18,8 @@ router.post('/', function(request, response) {
   var parsed = [];
   var minutes = "";
   var game = "";
+
+  debug('body', request.body);
 
   if (!token || token !== PEW_SLASH_TOKEN) {
     response.status(403).send('Unauthorized');
@@ -32,6 +35,8 @@ router.post('/', function(request, response) {
     message.push(game, "in", minutes, "minutes");
     message = _.compact(message);
   }
+
+  debug('sending', message.join(' '));
 
   slack.send({
     icon_emoji: ':bomb:',

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,15 @@
+// Common behavior
+
+module.exports = {
+  ensureToken: function(request, path) {
+    describe('validate token', function() {
+      it('should return 403 if mismatched token', function(done) {
+        request.post(path)
+          .send({
+            token: 'invalid_token',
+          })
+          .expect(403, 'Unauthorized', done);
+      });
+    });
+  }
+}

--- a/test/pew.spec.js
+++ b/test/pew.spec.js
@@ -1,0 +1,109 @@
+process.env['PEW_SLACK_WEBHOOK_URL'] = 'http://fakeurl.com';
+var TOKEN = process.env['PEW_SLASH_TOKEN'] = 'faketoken';
+var VALID_PARAMETERS = {
+  token: TOKEN,
+  user_name: 'bob',
+  text: ''
+};
+
+var _ = require('lodash');
+var bodyParser = require('body-parser');
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var pew = require('../router/routes/pew');
+var app = require('express')();
+
+app.use(bodyParser.urlencoded({extended: true}));
+app.use(pew);
+
+var request = require('supertest')(app);
+var common = require('./common');
+
+var sendRequest = function(params, cb) {
+  params = params || {};
+  cb = cb || function() {};
+
+  return request.post('/')
+    .type('form')
+    .send(_.defaults(params, VALID_PARAMETERS))
+    .end(cb);
+};
+
+describe('PEW', function() {
+  beforeEach(function() {
+    this.send = sinon.stub(pew.slack, 'send');
+  });
+
+  afterEach(function() {
+    this.send.restore();
+  });
+
+  common.ensureToken(request, '/');
+
+  describe('valid request', function() {
+    it('should have user\'s name in username', function(done) {
+      sendRequest({
+        user_name: 'kelly'
+      });
+
+      setTimeout(function() {
+        assert.ok(this.send.calledOnce);
+
+        var arg = this.send.args[0][0];
+
+        assert.property(arg, 'username');
+        assert.include(arg.username, 'kelly');
+        done();
+      }.bind(this), 10);
+    });
+  });
+
+  describe('no parameters', function() {
+    it('should send message "PEW now"', function(done) {
+      sendRequest();
+
+      setTimeout(function() {
+        assert.ok(this.send.calledOnce);
+
+        var arg = this.send.args[0][0];
+
+        assert.strictEqual(arg.text, '<!group>: PEW now');
+        done();
+      }.bind(this), 10);
+    });
+  });
+
+  describe('with minutes', function() {
+    it('should send message "PEW in [X] minutes"', function(done) {
+      sendRequest({
+        text: '30'
+      });
+
+      setTimeout(function() {
+        assert.ok(this.send.calledOnce);
+
+        var arg = this.send.args[0][0];
+
+        assert.strictEqual(arg.text, '<!group>: PEW in 30 minutes');
+        done();
+      }.bind(this), 10);
+    });
+  });
+
+  describe('with minutes and game', function() {
+    it('should send message "PEW [game] in [X] minutes"', function(done) {
+      sendRequest({
+        text: '30 WT'
+      });
+
+      setTimeout(function() {
+        assert.ok(this.send.calledOnce);
+
+        var arg = this.send.args[0][0];
+
+        assert.strictEqual(arg.text, '<!group>: PEW WT in 30 minutes');
+        done();
+      }.bind(this), 10);
+    });
+  });
+});


### PR DESCRIPTION
- Add mocha, chai, sinon, supertest
- Add common validate token test
- Add pew tests for no params, minutes, and minutes + game

**Tests are failing since master is broken**

We have to awkwardly put assertions in a setTimeout because our integration doesn't respond if the request was successful. That means we have no idea when the slack library will actually send the message.
